### PR TITLE
fix const-correctness for some inherited methods

### DIFF
--- a/src/ofxBlackMagic/Frame.cpp
+++ b/src/ofxBlackMagic/Frame.cpp
@@ -72,22 +72,22 @@ namespace ofxBlackmagic {
 	}
 	
 	//----------
-	int Frame::getWidth() {
+	int Frame::getWidth() const {
 		return this->pixels.getWidth();
 	}
 
 	//----------
-	int Frame::getHeight() {
+	int Frame::getHeight() const {
 		return this->pixels.getHeight();
 	}
 
 	//----------
-	unsigned char* Frame::getPixels() {
-		return this->pixels.getPixels();
+	ofPixels& Frame::getPixels() {
+		return this->pixels;
 	}
 
 	//----------
-	ofPixels& Frame::getPixelsRef() {
+	const ofPixels& Frame::getPixels() const {
 		return this->pixels;
 	}
 

--- a/src/ofxBlackMagic/Frame.h
+++ b/src/ofxBlackMagic/Frame.h
@@ -15,16 +15,16 @@ namespace ofxBlackmagic {
 		void deallocate();
 		void copyFromFrame(IDeckLinkVideoFrame*);
 
-		int getWidth();
-		int getHeight();
+		int getWidth() const;
+		int getHeight() const;
 
 		ofMutex lock;
 
 		//--
 		//ofBaseHasPixels
 		//
-		unsigned char* getPixels();
-		ofPixels& getPixelsRef();
+		ofPixels& getPixels() override;
+		const ofPixels& getPixels() const override;
 		//
 		//--
 

--- a/src/ofxBlackMagic/Input.cpp
+++ b/src/ofxBlackMagic/Input.cpp
@@ -103,42 +103,52 @@ namespace ofxBlackmagic {
 	}
 
 	//---------
-	void Input::draw(float x, float y) {
+	void Input::draw(float x, float y) const {
 		this->draw(x, y, this->getWidth(), this->getHeight());
 	}
 
 	//---------
-	void Input::draw(float x, float y, float w, float h) {
-		this->getTextureReference().draw(x, y, w, h);
+	void Input::draw(float x, float y, float w, float h) const {
+		this->getTexture().draw(x, y, w, h);
 	}
 	
 	//---------
-	float Input::getWidth() {
+	float Input::getWidth() const {
 		return this->videoFrame.getWidth();
 	}
 
 	//---------
-	float Input::getHeight() {
+	float Input::getHeight() const {
 		return this->videoFrame.getHeight();
 	}
 
 	//---------
-	unsigned char* Input::getPixels() {
+	ofPixels& Input::getPixels() {
 		return this->videoFrame.getPixels();
 	}
 
 	//---------
-	ofPixels& Input::getPixelsRef() {
-		return this->videoFrame.getPixelsRef();
+	const ofPixels& Input::getPixels() const {
+		return this->videoFrame.getPixels();
 	}
 
 	//---------
-	ofTexture& Input::getTextureReference() {
+	ofTexture& Input::getTexture() {
+		return this->texture;
+	}
+
+	//---------
+	const ofTexture& Input::getTexture() const {
 		return this->texture;
 	}
 
 	//---------
 	void Input::setUseTexture(bool useTexture) {
 		this->useTexture = useTexture;
+	}
+	
+	//---------
+	bool Input::isUsingTexture() const {
+		return this->useTexture;
 	}
 }

--- a/src/ofxBlackMagic/Input.h
+++ b/src/ofxBlackMagic/Input.h
@@ -43,10 +43,10 @@ namespace ofxBlackmagic {
 		//--
 		//ofBaseDraws
 		//
-		void draw(float x, float y) override;
-		void draw(float x, float y, float w, float h) override;
-		float getWidth() override;
-		float getHeight() override;
+		void draw(float x, float y) const override;
+		void draw(float x, float y, float w, float h) const override;
+		float getWidth() const override;
+		float getHeight() const override;
 		//
 		//--
 
@@ -54,8 +54,8 @@ namespace ofxBlackmagic {
 		//--
 		//ofBaseHasPixels
 		//
-		unsigned char* getPixels() override;
-		ofPixels& getPixelsRef() override;
+		ofPixels& getPixels() override;
+		const ofPixels& getPixels() const override;
 		//
 		//--
 
@@ -63,8 +63,11 @@ namespace ofxBlackmagic {
 		//--
 		//ofBaseHasTexture
 		//
-		ofTexture& getTextureReference() override;
+		ofTexture& getTexture() override;
+		const ofTexture& getTexture() const override;
+
 		void setUseTexture(bool) override;
+		bool isUsingTexture() const override;
 		//
 		//--
 


### PR DESCRIPTION
This fixes / and or sets const correctness for methods inherited from baseDraws, basePixels, and baseHasTexture, so that addon can be used with current oF master/upstream, and upcoming oF 0.9 release.

* Also moves from deprecated get*Ref() to get*() where needed.

This is a WIP, and will only be useful to merge once oF 0.9 has been released.