### PR TITLE
added fix for black frames using non-4k resolutions on Intensity 4k

### DIFF
--- a/src/ofxBlackMagic/Frame.cpp
+++ b/src/ofxBlackMagic/Frame.cpp
@@ -62,7 +62,10 @@ namespace ofxBlackmagic {
 		case bmdFormat10BitRGB:
 		case bmdFormat10BitRGBXLE:
 		case bmdFormat10BitRGBX:
-			throw(std::runtime_error("Format not supported yet"));
+		{
+			auto & converter = Utils::CoManager::X().getVideoConverter();
+			converter.ConvertFrame(inputFrame, this);
+		}
 			break;
 		default:
 			break;


### PR DESCRIPTION
This enables format auto-detection and allows an Intensity 4K to capture non-4k frames.