### PR TITLE
input color conversion is totally done in decklink thread

### DIFF
--- a/src/ofxBlackMagic/Frame.cpp
+++ b/src/ofxBlackMagic/Frame.cpp
@@ -88,6 +88,13 @@ namespace ofxBlackmagic {
 
 		//inputFrame->GetAncillaryData(&this->ancillary);
 	}
+	//----------
+	void Frame::swapFrame(Frame & fr)
+	{
+		std::swap(this->timecode, fr.timecode);
+		this->pixels.swap(fr.pixels);
+		std::swap(this->data, fr.data);
+	}
 	
 	//----------
 	int Frame::getWidth() const {

--- a/src/ofxBlackMagic/Frame.h
+++ b/src/ofxBlackMagic/Frame.h
@@ -18,9 +18,11 @@ namespace ofxBlackmagic {
 
 		Frame();
 		~Frame();
+
 		void allocate(int width, int height);
 		void deallocate();
 		void copyFromFrame(IDeckLinkVideoFrame*);
+		void swapFrame(Frame& fr);
 
 		int getWidth() const;
 		int getHeight() const;

--- a/src/ofxBlackMagic/Input.cpp
+++ b/src/ofxBlackMagic/Input.cpp
@@ -161,8 +161,10 @@ namespace ofxBlackmagic {
 			return S_OK;
 		}
 
+		this->videoFrameInput.copyFromFrame(videoFrame);
+
 		this->videoFrame.lock.lock();
-		this->videoFrame.copyFromFrame(videoFrame);
+		this->videoFrame.swapFrame(this->videoFrameInput);
 		this->videoFrame.lock.unlock();
 		this->newFrameReady = true;
 

--- a/src/ofxBlackMagic/Input.h
+++ b/src/ofxBlackMagic/Input.h
@@ -85,6 +85,7 @@ namespace ofxBlackmagic {
 		DeviceDefinition device;
 		IDeckLinkInput* input;
 		Frame videoFrame;
+		Frame videoFrameInput;
 		ofTexture texture;
 		bool useTexture;
 


### PR DESCRIPTION
Hi current implementation occupies GL thread during color conversion.
It takes 5-6msec for single HD image in my enverionment and,
If we use multiple decklink device (i.e DeckLink Duo2), we can't get 60fps in GL thread.
So i changed color conversion in decklink input thread.